### PR TITLE
Feature/sdk 136

### DIFF
--- a/Source/XsollaStore/Private/XsollaStoreImageLoader.cpp
+++ b/Source/XsollaStore/Private/XsollaStoreImageLoader.cpp
@@ -32,8 +32,8 @@ void UXsollaStoreImageLoader::LoadImage(FString URL, const FOnImageLoaded& Succe
 	{
 		if (PendingRequests.Contains(ResourceId))
 		{
-			PendingRequests[ResourceId].AddLambda([=](bool isCompleted) {
-				if (isCompleted)
+			PendingRequests[ResourceId].AddLambda([=](bool IsCompleted) {
+				if (IsCompleted)
 				{
 					UE_LOG(LogXsollaStore, VeryVerbose, TEXT("%s: Loaded from cache: %s"), *VA_FUNC_LINE, *ResourceId);
 					SuccessCallback.ExecuteIfBound(*ImageBrushes.Find(ResourceId)->Get());
@@ -118,7 +118,11 @@ void UXsollaStoreImageLoader::LoadImage_HttpRequestComplete(FHttpRequestPtr Http
 
 	ErrorCallback.ExecuteIfBound();
 
-	PendingRequests[ResourceName.ToString()].Broadcast(false);
+	if (PendingRequests.Contains(ResourceName.ToString()))
+	{
+		PendingRequests[ResourceName.ToString()].Broadcast(false);
+		PendingRequests.Remove(ResourceName.ToString());
+	}
 }
 
 FName UXsollaStoreImageLoader::GetCacheName(const FString& URL) const

--- a/Source/XsollaStore/Public/XsollaStoreImageLoader.h
+++ b/Source/XsollaStore/Public/XsollaStoreImageLoader.h
@@ -11,6 +11,7 @@
 
 DECLARE_DYNAMIC_DELEGATE_OneParam(FOnImageLoaded, FSlateBrush, ImageBrush);
 DECLARE_DYNAMIC_DELEGATE(FOnImageLoadFailed);
+DECLARE_MULTICAST_DELEGATE_OneParam(FOnRequestCompleted, bool);
 
 /**
  * Async image loading from web. Should be used for DEMO PUPPOSES ONLY.
@@ -35,6 +36,6 @@ private:
 	/** Internal brushes cache */
 	TMap<FString, TSharedPtr<FSlateDynamicImageBrush>> ImageBrushes;
 
-	/** Internal cache for pending requests */
-	TMap<FString, TArray<FOnImageLoaded>> PendingRequests;
+	/** Internal cache for pending requests callbacks */
+	TMap<FString, FOnRequestCompleted> PendingRequests;
 };

--- a/Source/XsollaStore/Public/XsollaStoreImageLoader.h
+++ b/Source/XsollaStore/Public/XsollaStoreImageLoader.h
@@ -34,4 +34,7 @@ private:
 
 	/** Internal brushes cache */
 	TMap<FString, TSharedPtr<FSlateDynamicImageBrush>> ImageBrushes;
+
+	/** Internal cache for pending requests */
+	TMap<FString, TArray<FOnImageLoaded>> PendingRequests;
 };


### PR DESCRIPTION
Если в момент когда нужно отобразить картинку уже есть активный запрос выполняющий ее скачивание, то просто ждем его результат вместо создания еще одного аналогичного запроса. Это позволяет устранить ситуацию когда одновременно стартуют несколько запросов для скачивания одной и той же картинки в результате чего сервак иногда отдает ошибку. Данный подход вполне рабочий и сейчас используется в Unity.