### PR TITLE
AES-256 Encryption for cached credentials

### DIFF
--- a/Source/XsollaLogin/Private/XsollaLoginSave.cpp
+++ b/Source/XsollaLogin/Private/XsollaLoginSave.cpp
@@ -2,32 +2,177 @@
 // @author Vladimir Alyamkin <ufna@ufna.ru>
 
 #include "XsollaLoginSave.h"
+#include "XsollaLogin.h"
+#include "XsollaLoginSettings.h"
 
 #include "Kismet/GameplayStatics.h"
+#include "Runtime/Core/Public/Misc/AES.h"
+#include "Runtime/Core/Public/Misc/Base64.h"
+#include "Runtime/PakFile/Public/IPlatformFilePak.h"
 
 const FString UXsollaLoginSave::SaveSlotName = "XsollaLoginSaveSlot";
 const int32 UXsollaLoginSave::UserIndex = 0;
 
 FXsollaLoginData UXsollaLoginSave::Load()
 {
-	auto SaveInstance = Cast<UXsollaLoginSave>(UGameplayStatics::LoadGameFromSlot(UXsollaLoginSave::SaveSlotName, UXsollaLoginSave::UserIndex));
+	const auto SaveInstance = Cast<UXsollaLoginSave>(UGameplayStatics::LoadGameFromSlot(SaveSlotName, UserIndex));
 	if (!SaveInstance)
 	{
 		return FXsollaLoginData();
 	}
 
-	return SaveInstance->LoginData;
+	// Decrypt the players sensitive credentials using an AES-256 encryption key if enabled
+	const UXsollaLoginSettings* Settings = FXsollaLoginModule::Get().GetSettings();
+	FXsollaLoginData CachedLoginData = SaveInstance->LoginData;
+
+	if (Settings->EncryptCachedCredentials && CachedLoginData.bEncrypted)
+	{
+		const FAES::FAESKey XsollaSaveEncryptionKey = GetEncryptionKey();
+
+		if (XsollaSaveEncryptionKey.IsValid())
+		{
+			CachedLoginData.AuthToken.JWT = DecryptString(CachedLoginData.AuthToken.JWT, XsollaSaveEncryptionKey);
+			CachedLoginData.Username = DecryptString(CachedLoginData.Username, XsollaSaveEncryptionKey);
+			CachedLoginData.Password = DecryptString(CachedLoginData.Password, XsollaSaveEncryptionKey);
+
+			//UE_LOG(LogXsollaLogin, Verbose, TEXT("Xsolla Cached Credentials Decrypted:\nJWT: %s\nUsername: %s\nPassword: %s\n"), *CachedLoginData.AuthToken.JWT, *CachedLoginData.Username, *CachedLoginData.Password);
+		}
+		else
+		{
+			UE_LOG(LogXsollaLogin, Error, TEXT("Xsolla Login Save Encryption Key was Invalid!"));
+		}
+	}
+	else
+	{
+		UE_LOG(LogXsollaLogin, Verbose, TEXT("Xsolla Login Save Encryption is disabled, skipping."));
+	}
+
+	return CachedLoginData;
 }
 
 void UXsollaLoginSave::Save(const FXsollaLoginData& InLoginData)
 {
-	auto SaveInstance = Cast<UXsollaLoginSave>(UGameplayStatics::LoadGameFromSlot(UXsollaLoginSave::SaveSlotName, UXsollaLoginSave::UserIndex));
+	auto SaveInstance = Cast<UXsollaLoginSave>(UGameplayStatics::LoadGameFromSlot(SaveSlotName, UserIndex));
 	if (!SaveInstance)
 	{
-		SaveInstance = Cast<UXsollaLoginSave>(UGameplayStatics::CreateSaveGameObject(UXsollaLoginSave::StaticClass()));
+		SaveInstance = Cast<UXsollaLoginSave>(UGameplayStatics::CreateSaveGameObject(StaticClass()));
 	}
 
-	SaveInstance->LoginData = InLoginData;
+	// Encrypt the players sensitive credentials using a secondary AES-256 encryption key configured for the project if enabled
+	const UXsollaLoginSettings* Settings = FXsollaLoginModule::Get().GetSettings();
+	FXsollaLoginData CachedLoginData = InLoginData;
+	
+	if (Settings->EncryptCachedCredentials)
+	{
+		const FAES::FAESKey XsollaSaveEncryptionKey = GetEncryptionKey();
 
-	UGameplayStatics::SaveGameToSlot(SaveInstance, UXsollaLoginSave::SaveSlotName, 0);
+		if (XsollaSaveEncryptionKey.IsValid())
+		{
+			const FString KeyStr = FBase64::Encode(XsollaSaveEncryptionKey.Key, XsollaSaveEncryptionKey.KeySize);
+			
+			CachedLoginData.AuthToken.JWT = EncryptString(CachedLoginData.AuthToken.JWT, XsollaSaveEncryptionKey);
+			CachedLoginData.Username = EncryptString(CachedLoginData.Username, XsollaSaveEncryptionKey);
+			CachedLoginData.Password = EncryptString(CachedLoginData.Password, XsollaSaveEncryptionKey);
+			CachedLoginData.bEncrypted = true;
+
+			//UE_LOG(LogXsollaLogin, Verbose, TEXT("Xsolla Cached Credentials Encrypted:\nJWT: %s\nUsername: %s\nPassword: %s\n"), *CachedLoginData.AuthToken.JWT, *CachedLoginData.Username, *CachedLoginData.Password);
+		}
+		else
+		{
+			UE_LOG(LogXsollaLogin, Error, TEXT("Xsolla Login Save Encryption Key was Invalid!"));
+		}
+		
+	}
+	else
+	{
+		UE_LOG(LogXsollaLogin, Verbose, TEXT("Xsolla Login Save Encryption is disabled, skipping."));
+	}
+
+	SaveInstance->LoginData = CachedLoginData;
+
+	UGameplayStatics::SaveGameToSlot(SaveInstance, SaveSlotName, 0);
+}
+
+FAES::FAESKey UXsollaLoginSave::GetEncryptionKey()
+{
+	const UXsollaLoginSettings* Settings = FXsollaLoginModule::Get().GetSettings();
+	FAES::FAESKey CachedEncryptionKey = FAES::FAESKey();
+	
+	if (Settings->XsollaSaveEncryptionKey.IsEmpty())
+	{
+		return CachedEncryptionKey;
+	}
+
+	TArray<uint8> Key;
+	if (FBase64::Decode(Settings->XsollaSaveEncryptionKey, Key))
+	{
+		check(Key.Num() == sizeof(FAES::FAESKey::Key));
+
+		FMemory::Memcpy(CachedEncryptionKey.Key, &Key[0], sizeof(FAES::FAESKey::Key));
+
+		check(CachedEncryptionKey.IsValid());
+	}
+
+	return CachedEncryptionKey;
+}
+
+FString UXsollaLoginSave::EncryptString(const FString& InString, const FAES::FAESKey& InKey)
+{
+	if (InString.IsEmpty())
+	{
+		return FString();
+	}
+
+	if (!InKey.IsValid())
+	{
+		UE_LOG(LogXsollaLogin, Error, TEXT("DecryptString received invalid AES-256 key!"));
+
+		return FString();
+	}
+	
+	// For simplicities sake, trim away aes block padding by splitting left of the || symbol
+	const FString PadStr = FString::Printf(TEXT("%s||"), *InString);
+	
+	TArray<uint8> Bytes;
+	const uint32 NumBytes = Align(PadStr.Len(), FAES::AESBlockSize);
+	
+	Bytes.SetNumUninitialized(NumBytes);
+
+	StringToBytes(PadStr, Bytes.GetData(), Bytes.Num());
+
+	FAES::EncryptData(Bytes.GetData(), NumBytes, InKey);
+	
+	return BytesToString(Bytes.GetData(), NumBytes);
+}
+
+FString UXsollaLoginSave::DecryptString(const FString& InString, const FAES::FAESKey& InKey)
+{
+	if (InString.IsEmpty() || !InKey.IsValid())
+	{
+		return FString();
+	}
+
+	if (!InKey.IsValid())
+	{
+		UE_LOG(LogXsollaLogin, Error, TEXT("DecryptString received invalid AES-256 key!"));
+
+		return FString();
+	}
+
+	TArray<uint8> Bytes;
+	const uint32 NumBytes = Align(InString.Len(), FAES::AESBlockSize);
+
+	Bytes.SetNumUninitialized(NumBytes);
+
+	StringToBytes(InString, Bytes.GetData(), Bytes.Num());
+
+	FAES::DecryptData(Bytes.GetData(), NumBytes, InKey);
+
+	const FString DecryptedString = BytesToString(Bytes.GetData(), NumBytes);
+	FString LeftString;
+	FString RightString;
+
+	DecryptedString.Split("||", &LeftString, &RightString, ESearchCase::CaseSensitive);
+	
+	return LeftString;
 }

--- a/Source/XsollaLogin/Private/XsollaLoginSave.cpp
+++ b/Source/XsollaLogin/Private/XsollaLoginSave.cpp
@@ -8,7 +8,6 @@
 #include "Kismet/GameplayStatics.h"
 #include "Runtime/Core/Public/Misc/AES.h"
 #include "Runtime/Core/Public/Misc/Base64.h"
-#include "Runtime/PakFile/Public/IPlatformFilePak.h"
 
 const FString UXsollaLoginSave::SaveSlotName = "XsollaLoginSaveSlot";
 const int32 UXsollaLoginSave::UserIndex = 0;
@@ -125,7 +124,7 @@ FString UXsollaLoginSave::EncryptString(const FString& InString, const FAES::FAE
 
 	if (!InKey.IsValid())
 	{
-		UE_LOG(LogXsollaLogin, Error, TEXT("DecryptString received invalid AES-256 key!"));
+		UE_LOG(LogXsollaLogin, Error, TEXT("EncryptString received invalid AES-256 key!"));
 
 		return FString();
 	}

--- a/Source/XsollaLogin/Public/XsollaLoginSave.h
+++ b/Source/XsollaLogin/Public/XsollaLoginSave.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "XsollaLoginTypes.h"
-
+#include "Runtime/Core/Public/Misc/AES.h"
 #include "GameFramework/SaveGame.h"
 
 #include "XsollaLoginSave.generated.h"
@@ -17,6 +17,10 @@ class UXsollaLoginSave : public USaveGame
 public:
 	static FXsollaLoginData Load();
 	static void Save(const FXsollaLoginData& InLoginData);
+
+	static FAES::FAESKey GetEncryptionKey();
+	static FString EncryptString(const FString& InString, const FAES::FAESKey& InKey);
+	static FString DecryptString(const FString& InString, const FAES::FAESKey& InKey);
 
 public:
 	static const FString SaveSlotName;

--- a/Source/XsollaLogin/Public/XsollaLoginSettings.h
+++ b/Source/XsollaLogin/Public/XsollaLoginSettings.h
@@ -85,6 +85,14 @@ public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Xsolla Login Settings")
 	FString AccountLinkingURL;
 
+	/** Flag indicating whether Xsolla cached credentials should be encrypted and decrypted using the XsollaSaveEncryptionKey secondary encryption key */
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Xsolla Login Settings")
+	bool EncryptCachedCredentials;
+	
+	/** AES-256 encryption key to use when encrypting Xsolla cached credentials */
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Xsolla Login Settings")
+	FString XsollaSaveEncryptionKey;
+	
 	/** Flag indicating whether this build is targeted for specific platform */
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "Xsolla Login Settings")
 	bool PlatformBuild;

--- a/Source/XsollaLogin/Public/XsollaLoginTypes.h
+++ b/Source/XsollaLogin/Public/XsollaLoginTypes.h
@@ -41,8 +41,11 @@ struct FXsollaLoginData
 	UPROPERTY(BlueprintReadOnly, Category = "Login Data")
 	bool bRememberMe;
 
+	UPROPERTY(BlueprintReadOnly, Category = "Login Data")
+	bool bEncrypted;
+
 	FXsollaLoginData()
-		: bRememberMe(false)
+		: bRememberMe(false), bEncrypted(false)
 	{
 	}
 };

--- a/Source/XsollaLogin/XsollaLogin.Build.cs
+++ b/Source/XsollaLogin/XsollaLogin.Build.cs
@@ -18,7 +18,8 @@ public class XsollaLogin : ModuleRules
                 "JsonUtilities",
                 "UMG",
                 "OnlineSubsystem",
-                "XsollaWebBrowser"
+                "XsollaWebBrowser",
+                "PakFile"
             }
             );
 

--- a/Source/XsollaLogin/XsollaLogin.Build.cs
+++ b/Source/XsollaLogin/XsollaLogin.Build.cs
@@ -18,8 +18,7 @@ public class XsollaLogin : ModuleRules
                 "JsonUtilities",
                 "UMG",
                 "OnlineSubsystem",
-                "XsollaWebBrowser",
-                "PakFile"
+                "XsollaWebBrowser"
             }
             );
 


### PR DESCRIPTION
I have implemented a rudimentary string encryption and decryption functionality using the built-in AES-256 library to XsollaLoginSave to avoid storing plaintext player credentials on the file system.

Simply enable save file encryption and supply a valid AES-256 encryption key under the Xsolla Login plugin settings, and enable PakFile ini encryption for the project as a whole under Crypto settings, so that the key is kept within the encrypted pak file. It's not perfect, but it's better than nothing for now.